### PR TITLE
Add right to left direction support

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,6 +12,7 @@ class MyApp extends StatefulWidget {
 
 class _MyAppState extends State<MyApp> {
   final _selectedSegment_0 = AdvancedSegmentController('all');
+  final _selectedSegment_01 = AdvancedSegmentController('all');
   final _selectedSegment_1 = AdvancedSegmentController('all');
   final _selectedSegment_2 = AdvancedSegmentController('all');
   final _selectedSegment_3 = AdvancedSegmentController('all');
@@ -38,6 +39,14 @@ class _MyAppState extends State<MyApp> {
                     'starred': 'Starred',
                   },
                   controller: _selectedSegment_0,
+                ),
+                _buildLabel('Regular Right to Left'),
+                Directionality(
+                  textDirection: TextDirection.rtl,
+                  child: AdvancedSegment(
+                    controller: _selectedSegment_01,
+                    segments: {'all': 'All', 'starred': 'Starred'},
+                  ),
                 ),
                 _buildLabel('Disabled'),
                 Row(

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -157,8 +157,8 @@ class _AdvancedSegmentState extends State<AdvancedSegment>
       builder: (context, child) {
         return Transform.translate(
           offset: Tween<Offset>(
-            begin: Offset(0, 0),
-            end: Offset(_itemSize.width * (widget.segments.length - 1), 0),
+            begin: Offset.zero,
+            end: _obtainEndOffset(Directionality.of(context)),
           )
               .animate(CurvedAnimation(
                 parent: _animationController,
@@ -261,6 +261,14 @@ class _AdvancedSegmentState extends State<AdvancedSegment>
         _controller.value = widget.segments.keys.elementAt(indexMove.toInt());
       }
     }
+  }
+
+  Offset _obtainEndOffset(TextDirection textDirection) {
+    if (textDirection == TextDirection.rtl) {
+      return Offset(-(_itemSize.width * (widget.segments.length - 1)), 0);
+    }
+
+    return Offset(_itemSize.width * (widget.segments.length - 1), 0);
   }
 
   @override


### PR DESCRIPTION
Added fix for Arabic-like languages which commonly uses right-to-left text direction along with Directionality widget. Before was wrong behaviour if we wrap `AdvancedSegment` with `Directionality` slider was still animating to right when is supposed to be animated left-side. This PR fixes the problem.